### PR TITLE
chore: add 'outputs/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+outputs/
 downloads/
 eggs/
 .eggs/


### PR DESCRIPTION
Adds the 'outputs/' directory to the .gitignore file to exclude it from version control. This is necessary as the 'outputs/' directory is used to store generated files that should not be tracked by git.