### PR TITLE
Ensure torchrun compatibility 

### DIFF
--- a/src/ntl/trainer.py
+++ b/src/ntl/trainer.py
@@ -1271,7 +1271,9 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             labels = inputs["labels"]
         else:
             labels = None
+        print('Before IN')
         outputs = model(**inputs)
+        print('Done with forward pass')
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.
         if self.args.past_index >= 0:

--- a/src/ntl/trainer.py
+++ b/src/ntl/trainer.py
@@ -1297,9 +1297,7 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             labels = inputs["labels"]
         else:
             labels = None
-        print('Before IN', type(model))
         outputs = model(**inputs)
-        print('Done with forward pass')
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.
         if self.args.past_index >= 0:

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -53,11 +53,8 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             return_dict=return_dict,
         )
         print('Out meta', type(outputs))
-        from dataclasses import asdict
-        for k,v in asdict(outputs).items():
-            print(k, type(v))
-            if isinstance(v, torch.Tensor):
-                print(v.shape)
+        from dataclasses import fields
+        print(outputs)
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
@@ -66,8 +63,6 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             outputs["token_loss"] = outputs.loss
             outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
             print('Entered NTL', type(outputs))
-            for k,v in asdict(outputs).items():
-                print(k, type(v))
-                if isinstance(v, torch.Tensor):
-                    print(v.shape)
+            for field in fields(outputs):
+                print(f"{field.name}: {getattr(outputs, field.name)}")
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -55,7 +55,9 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
         print('Out meta', type(outputs))
         from dataclasses import asdict
         for k,v in asdict(outputs).items():
-            print(k, v.shape)
+            print(k, type(v))
+            if isinstance(v, torch.Tensor):
+                print(v.shape)
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
@@ -65,5 +67,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
             print('Entered NTL', type(outputs))
             for k,v in asdict(outputs).items():
-                print(k, v.shape)
+            print(k, type(v))
+            if isinstance(v, torch.Tensor):
+                print(v.shape)
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -55,6 +55,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
         print("TYPE outputs", type(outputs))
         from dataclasses import fields
 
+        import torch
         import transformers
 
         # If labels are provided, calculate and combine the NumberTokenLoss
@@ -67,5 +68,5 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             )
             print("Entered NTL", type(outputs))
             print(outputs.loss, outputs.keys(), outputs.number_loss)
-            print(transformers.__version__)
+            print(transformers.__version__, torch.__version__)
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -1,7 +1,9 @@
+from typing import Optional, Tuple, Union
+
+import torch
 from transformers import T5ForConditionalGeneration
 from transformers.modeling_outputs import Seq2SeqLMOutput
-import torch
-from typing import Optional, Tuple, Union
+
 from ntl.loss_functions.number_token_loss import NumberTokenLoss
 
 
@@ -32,6 +34,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             return_dict: Optional[bool] = None,
     ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
         # Call the parent's forward method
+        print('IN', input_ids.shape)
         outputs = super().forward(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -50,6 +53,10 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
+        print('Out meta', type(outputs))
+        from dataclasses import asdict
+        for k,v in asdict(outputs).items():
+            print(k, v.shape)
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
@@ -57,4 +64,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             outputs["number_loss"] = number_token_loss
             outputs["token_loss"] = outputs.loss
             outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
+            print('Entered NTL', type(outputs))
+            for k,v in asdict(outputs).items():
+                print(k, v.shape)
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -59,7 +59,6 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
-        print("TYPE outputs", type(outputs))
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
@@ -70,6 +69,5 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
                 token_loss=outputs.loss,
                 loss=(outputs.loss + self.number_token_loss.weight * number_token_loss),
             )
-            print("type", type(outputs), outputs.loss, outputs.number_loss)
 
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -34,7 +34,6 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             return_dict: Optional[bool] = None,
     ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
         # Call the parent's forward method
-        print('IN', input_ids.shape)
         outputs = super().forward(
             input_ids=input_ids,
             attention_mask=attention_mask,

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -54,15 +54,14 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
         )
         print('Out meta', type(outputs))
         from dataclasses import fields
-        print(outputs)
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
             number_token_loss = self.number_token_loss.forward(outputs.logits, labels)
-            outputs["number_loss"] = number_token_loss
-            outputs["token_loss"] = outputs.loss
+            # outputs["number_loss"] = number_token_loss
+            # outputs["token_loss"] = outputs.loss
             outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
             print('Entered NTL', type(outputs))
             for field in fields(outputs):
-                print(f"{field.name}: {getattr(outputs, field.name)}")
+                print(f"{field.name}: {type(getattr(outputs, field.name))}")
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -15,23 +15,23 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
         self.number_token_loss = number_token_loss
 
     def forward(
-            self,
-            input_ids: Optional[torch.LongTensor] = None,
-            attention_mask: Optional[torch.FloatTensor] = None,
-            decoder_input_ids: Optional[torch.LongTensor] = None,
-            decoder_attention_mask: Optional[torch.BoolTensor] = None,
-            head_mask: Optional[torch.FloatTensor] = None,
-            decoder_head_mask: Optional[torch.FloatTensor] = None,
-            cross_attn_head_mask: Optional[torch.Tensor] = None,
-            encoder_outputs: Optional[Tuple[Tuple[torch.Tensor]]] = None,
-            past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
-            inputs_embeds: Optional[torch.FloatTensor] = None,
-            decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
-            labels: Optional[torch.LongTensor] = None,
-            use_cache: Optional[bool] = None,
-            output_attentions: Optional[bool] = None,
-            output_hidden_states: Optional[bool] = None,
-            return_dict: Optional[bool] = None,
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        decoder_input_ids: Optional[torch.LongTensor] = None,
+        decoder_attention_mask: Optional[torch.BoolTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        decoder_head_mask: Optional[torch.FloatTensor] = None,
+        cross_attn_head_mask: Optional[torch.Tensor] = None,
+        encoder_outputs: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
         # Call the parent's forward method
         outputs = super().forward(
@@ -52,16 +52,20 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
-        print('Out meta', type(outputs))
+        print("TYPE outputs", type(outputs))
         from dataclasses import fields
+
+        import transformers
 
         # If labels are provided, calculate and combine the NumberTokenLoss
         if labels is not None and self.number_token_loss is not None:
             number_token_loss = self.number_token_loss.forward(outputs.logits, labels)
-            # outputs["number_loss"] = number_token_loss
-            # outputs["token_loss"] = outputs.loss
-            outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
-            print('Entered NTL', type(outputs))
-            for field in fields(outputs):
-                print(f"{field.name}: {type(getattr(outputs, field.name))}")
+            outputs["number_loss"] = number_token_loss
+            outputs["token_loss"] = outputs.loss
+            outputs.loss = (
+                outputs.loss + self.number_token_loss.weight * number_token_loss
+            )
+            print("Entered NTL", type(outputs))
+            print(outputs.loss, outputs.keys(), outputs.number_loss)
+            print(transformers.__version__)
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -67,7 +67,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
             outputs.loss = outputs.loss + self.number_token_loss.weight * number_token_loss
             print('Entered NTL', type(outputs))
             for k,v in asdict(outputs).items():
-            print(k, type(v))
-            if isinstance(v, torch.Tensor):
-                print(v.shape)
+                print(k, type(v))
+                if isinstance(v, torch.Tensor):
+                    print(v.shape)
         return outputs

--- a/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
+++ b/src/ntl/transformer_backbone/t5/t5_vanilla_for_number_token_loss.py
@@ -32,7 +32,7 @@ class T5VanillaForNumberTokenLoss(T5ForConditionalGeneration):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
+    ):
         # Call the parent's forward method
         outputs = super().forward(
             input_ids=input_ids,


### PR DESCRIPTION
Current trainer is not compatible with distributed training because the return type object (`Seq2SeqLMOutput`) is altered within our child class which is not permitted as per distributed training.

I abstracted the return type logic to enforce compatibility