### PR TITLE
Add Lightweight Runtime Benchmarking for Loss Functions

### DIFF
--- a/benchmarking/runtime_sanity_check.py
+++ b/benchmarking/runtime_sanity_check.py
@@ -15,28 +15,35 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-def benchmark(loss, time_steps, vocab_size, batch_size, device, permute=False):
+def benchmark(loss, time_steps, vocab_size, batch_size, device, permute = False, number_token_ids = None):
 
     # Clear cache
     torch.cuda.empty_cache()
 
     # Generate random input
     logits = torch.randn(batch_size, time_steps, vocab_size).to(device)
-    labels = torch.randint(vocab_size, (batch_size, time_steps)).to(device)
+
+    # Generate random labels
+    if number_token_ids:
+        # Fill labels with ids only of number tokens to ensure ntl has something to compute
+        indices = torch.randint(0, len(number_token_ids), (batch_size, time_steps))
+        labels = torch.tensor(number_token_ids)[indices].to(device)
+    else:
+        labels = torch.randint(vocab_size, (batch_size, time_steps)).to(device)
 
     # Permute shape for ce loss
     if permute:
         logits = logits.permute(0, 2, 1)
 
     # Sync and start timer
-    torch.cuda.synchronize()
+    # torch.cuda.synchronize()
     start = time.perf_counter()
 
     # Compute Loss
-    loss(logits, labels)
+    print(loss(logits, labels))
 
     # Sync and stop timer
-    torch.cuda.synchronize()
+    # torch.cuda.synchronize()
     end = time.perf_counter()
 
     return end - start
@@ -54,6 +61,9 @@ def runtime_measurement(time_steps, batch_size, num_batches):
     ntl = NumberTokenLoss(tokenizer)
     ce_with_ntl = CEWithNTL(tokenizer)
 
+    number_tokens = map(str, ntl.nt_vals_dense.tolist())
+    number_token_ids = tokenizer.convert_tokens_to_ids(number_tokens)
+
     ce_times = []
     ntl_times = []
     ce_with_ntl_times = []
@@ -61,8 +71,8 @@ def runtime_measurement(time_steps, batch_size, num_batches):
     for _ in range(num_batches):
 
         ce_time = benchmark(ce_loss, time_steps, vocab_size, batch_size, device, permute=True)
-        ntl_time = benchmark(ntl, time_steps, vocab_size, batch_size, device)
-        ce_with_ntl_time = benchmark(ce_with_ntl, time_steps, vocab_size, batch_size, device)
+        ntl_time = benchmark(ntl, time_steps, vocab_size, batch_size, device, number_token_ids=number_token_ids)
+        ce_with_ntl_time = benchmark(ce_with_ntl, time_steps, vocab_size, batch_size, device, number_token_ids=number_token_ids)
 
         ce_times.append(ce_time)
         ntl_times.append(ntl_time)
@@ -83,4 +93,4 @@ def runtime_measurement(time_steps, batch_size, num_batches):
 
 
 if __name__ == "__main__":
-    runtime_measurement(time_steps = 10, batch_size = 32, num_batches = 100)
+    runtime_measurement(time_steps = 2, batch_size = 1, num_batches = 1)

--- a/benchmarking/runtime_sanity_check.py
+++ b/benchmarking/runtime_sanity_check.py
@@ -1,0 +1,86 @@
+import time
+import logging
+import torch
+import numpy as np
+from ntl.loss_functions.base_number_token_loss import NumberTokenLoss, CEWithNTL
+from ntl.tokenizer.t5custom_tokenizer import T5Custom_Tokenizer
+from torch.nn import CrossEntropyLoss
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] - [%(levelname)s] - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
+
+def benchmark(loss, time_steps, vocab_size, batch_size, device, permute=False):
+
+    # Clear cache
+    torch.cuda.empty_cache()
+
+    # Generate random input
+    logits = torch.randn(batch_size, time_steps, vocab_size).to(device)
+    labels = torch.randint(vocab_size, (batch_size, time_steps)).to(device)
+
+    # Permute shape for ce loss
+    if permute:
+        logits = logits.permute(0, 2, 1)
+
+    # Sync and start timer
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+
+    # Compute Loss
+    loss(logits, labels)
+
+    # Sync and stop timer
+    torch.cuda.synchronize()
+    end = time.perf_counter()
+
+    return end - start
+
+def runtime_measurement(time_steps, batch_size, num_batches):
+    
+    # Setup  
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info(f"Using device: {device}")
+
+    tokenizer = T5Custom_Tokenizer.from_pretrained("t5-small")
+    vocab_size = len(tokenizer)
+    
+    ce_loss = CrossEntropyLoss(ignore_index=-100)
+    ntl = NumberTokenLoss(tokenizer)
+    ce_with_ntl = CEWithNTL(tokenizer)
+
+    ce_times = []
+    ntl_times = []
+    ce_with_ntl_times = []
+
+    for _ in range(num_batches):
+
+        ce_time = benchmark(ce_loss, time_steps, vocab_size, batch_size, device, permute=True)
+        ntl_time = benchmark(ntl, time_steps, vocab_size, batch_size, device)
+        ce_with_ntl_time = benchmark(ce_with_ntl, time_steps, vocab_size, batch_size, device)
+
+        ce_times.append(ce_time)
+        ntl_times.append(ntl_time)
+        ce_with_ntl_times.append(ce_with_ntl_time)
+
+
+    # Calculate mean and standard deviation
+    ce_time = np.mean(ce_times)
+    ce_time_std = np.std(ce_times)
+    ntl_time = np.mean(ntl_times)
+    ntl_time_std = np.std(ntl_times)
+    ce_with_ntl_time = np.mean(ce_with_ntl_times)
+    ce_with_ntl_time_std = np.std(ce_with_ntl_times)
+
+    logger.info(f"CrossEntropyLoss: ({ce_time*1000:.2f} ± {ce_time_std*1000:.2f})ms")
+    logger.info(f"NumberTokenLoss: ({ntl_time*1000:.2f} ± {ntl_time_std*1000:.2f})ms")
+    logger.info(f"CEWithNTL: ({ce_with_ntl_time*1000:.2f} ± {ce_with_ntl_time_std*1000:.2f})ms")
+
+
+if __name__ == "__main__":
+    runtime_measurement(time_steps = 10, batch_size = 32, num_batches = 100)

--- a/benchmarking/runtime_sanity_check.py
+++ b/benchmarking/runtime_sanity_check.py
@@ -60,8 +60,8 @@ def runtime_measurement(time_steps, batch_size, num_batches):
     vocab_size = len(tokenizer)
     
     ce_loss = CrossEntropyLoss(ignore_index=-100)
-    ntl = NumberTokenLoss(tokenizer)
-    ce_with_ntl = CEWithNTL(tokenizer)
+    ntl = NumberTokenLoss(tokenizer, device)
+    ce_with_ntl = CEWithNTL(tokenizer, device)
 
     # Get number token ids
     ntl_number_token_ids = (~torch.isnan(ntl.nt_vals)).nonzero().squeeze()

--- a/benchmarking/runtime_sanity_check.py
+++ b/benchmarking/runtime_sanity_check.py
@@ -59,7 +59,7 @@ def runtime_measurement(time_steps, batch_size, num_batches):
     tokenizer = T5Custom_Tokenizer.from_pretrained("t5-small")
     vocab_size = len(tokenizer)
     
-    ce_loss = CrossEntropyLoss(ignore_index=-100)
+    ce_loss = CrossEntropyLoss(ignore_index=-100).to(device)
     ntl = NumberTokenLoss(tokenizer, device)
     ce_with_ntl = CEWithNTL(tokenizer, device)
 


### PR DESCRIPTION
This PR adds a script for a lightweight benchmark for the runtime of:

- `CrossEntropyLoss`
- `NumberTokenLoss`
- `CEWithNTL`

under two modes for the NTL calculation (to avoid NaNs):
- `tokenizer_modified`: all tokens treated as number tokens  
- `numbers_only`: only number tokens used in labels tensor

Key features:
- Uses only lightweight NTL version
- Accurate timing with CUDA sync
- Optional token filtering to avoid NaNs for NTL
- Logs mean ± std for each loss over multiple batches

**Sample output:**
```
Tokenzer modified (All tokens encoded as number tokens for ntl loss)
CrossEntropyLoss: (32.52 ± 0.50)ms
NumberTokenLoss: (9.15 ± 0.15)ms
CEWithNTL: (41.15 ± 0.29)ms
    
Numbers only (Only number tokens are used to compute ntl loss)
CrossEntropyLoss: (33.35 ± 0.02)ms
NumberTokenLoss: (0.44 ± 0.01)ms
CEWithNTL: (33.67 ± 0.02)ms
```

Useful for lightweight runtime comparison.