### PR TITLE
[minor] typo & readme badges rendering

### DIFF
--- a/ntloss/README.md
+++ b/ntloss/README.md
@@ -1,4 +1,5 @@
 <div align="center">
+
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PyPI](https://badge.fury.io/py/ntloss.svg)](https://badge.fury.io/py/ntloss)
 [![Downloads](https://static.pepy.tech/badge/ntloss)](https://pepy.tech/project/ntloss)

--- a/src/ntl/loss_functions/abs_diff_number_token_loss.py
+++ b/src/ntl/loss_functions/abs_diff_number_token_loss.py
@@ -9,7 +9,7 @@ logger = logging.get_logger(__name__)
 
 class AbsDiffNumberTokenLoss:
     """
-    Loss function for numberical tokens based on the weighted absolute difference between true and predicted number
+    Loss function for numerical tokens based on the weighted absolute difference between true and predicted number
     NOTE: This loss is equivalent to the Wasserstein distance as long as the ground truth distribution is one-hot
     """
 


### PR DESCRIPTION
Hello,

below are just some minor fixes while reading your awesome repo:

- typo in `AbsDiffNumberTokenLoss` docstring
- fixed badge rendering: added a whitespace